### PR TITLE
add a denylist of dengerous attributes in lodash.set/index.js

### DIFF
--- a/lodash.set/index.js
+++ b/lodash.set/index.js
@@ -508,7 +508,10 @@ function baseSet(object, path, value, customizer) {
   while (nested != null && ++index < length) {
     var key = toKey(path[index]),
         newValue = value;
-
+    
+    // CWE-1321 - use denylist of dangerous attributes
+    if (key in ["__proto__", "prototype", "constructor"]) continue
+      
     if (index != lastIndex) {
       var objValue = nested[key];
       newValue = customizer ? customizer(objValue, key, nested) : undefined;


### PR DESCRIPTION
CWE-1321 recommends using a deny-list of dangerous attributes to eliminate the risks of Prototype Pollution.

The method  "set" in the main package (lodash/lodash)  is safe but not the stand alone module (lodash/lodash.set).

example:
set({}, "__proto__.polluted", true);